### PR TITLE
community: tongyi multimodal response format fix to support langchain

### DIFF
--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -547,6 +547,18 @@ class ChatTongyi(BaseChatModel):
                 if _kwargs.get("stream") and not _kwargs.get(
                     "incremental_output", False
                 ):
+                    # inline fix response text logic
+                    resp_copy = json.loads(json.dumps(resp))
+                    choice = resp_copy["output"]["choices"][0]
+                    message = choice["message"]
+                    if isinstance(message.get("content"), list):
+                        content_text = "".join(
+                            item.get("text", "")
+                            for item in message["content"]
+                            if isinstance(item, dict)
+                        )
+                        message["content"] = content_text
+                    resp = resp_copy
                     if prev_resp is None:
                         delta_resp = resp
                     else:


### PR DESCRIPTION
Description: The multimodal(tongyi) response format "message": {"role": "assistant", "content": [{"text": "图像"}]}}]} is not compatible with LangChain.
Dependencies: No